### PR TITLE
Manual proxy was not taken into account in c# websocket code. Also th…

### DIFF
--- a/src/WebSocketClient.cs
+++ b/src/WebSocketClient.cs
@@ -209,29 +209,8 @@ namespace MeshCentralRouter
             else
             {
                 // Use C# coded websockets
-                Uri proxyUri = null;
+                Uri proxyUri = Win32Api.GetProxy(url);
                 Log("Websocket Start, URL=" + ((url == null) ? "(NULL)" : url.ToString()));
-
-                // Check if we need to use a HTTP proxy (Auto-proxy way)
-                try
-                {
-                    RegistryKey registryKey = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
-                    Object x = registryKey.GetValue("AutoConfigURL", null);
-                    if ((x != null) && (x.GetType() == typeof(string)))
-                    {
-                        string proxyStr = GetProxyForUrlUsingPac("http" + ((url.Port == 80) ? "" : "s") + "://" + url.Host + ":" + url.Port, x.ToString());
-                        if (proxyStr != null) { proxyUri = new Uri("http://" + proxyStr); }
-                    }
-                }
-                catch (Exception) { proxyUri = null; }
-
-                // Check if we need to use a HTTP proxy (Normal way)
-                if (proxyUri == null)
-                {
-                    var proxy = System.Net.HttpWebRequest.GetSystemWebProxy();
-                    proxyUri = proxy.GetProxy(url);
-                    if ((url.Host.ToLower() == proxyUri.Host.ToLower()) && (url.Port == proxyUri.Port)) { proxyUri = null; }
-                }
 
                 if (proxyUri != null)
                 {
@@ -288,7 +267,7 @@ namespace MeshCentralRouter
             {
                 // Send proxy connection request
                 wsrawstream = wsclient.GetStream();
-
+                Uri proxyUri = Win32Api.GetProxy(url);
                 string userCreds = proxyUri.UserInfo;
                 string basicAuth = "";
                 if (userCreds.Length > 0)


### PR DESCRIPTION
…ere was some duplicated code with the code in win32api.cs

proxyUri was undefined in OnConnectSink resulting in crash